### PR TITLE
Provide better error handling and error response parsing

### DIFF
--- a/Sources/SimpleNetworking/APIClientError.swift
+++ b/Sources/SimpleNetworking/APIClientError.swift
@@ -1,5 +1,5 @@
 //
-// BadStatusError.swift
+// APIClientError.swift
 //
 // Copyright (c) 2020 Guille Gonzalez
 //
@@ -23,8 +23,36 @@
 
 import Foundation
 
-public struct BadStatusError: Error {
-    public let data: Data
-    public let response: HTTPURLResponse
-    public var statusCode: Int { response.statusCode }
+public enum APIClientError<Error>: Swift.Error {
+    case loadingError(Swift.Error)
+    case decodingError(DecodingError)
+    case apiError(APIError<Error>)
+
+    internal init(_ error: Swift.Error) {
+        switch error {
+        case let apiError as APIError<Error>:
+            self = .apiError(apiError)
+        case let decodingError as DecodingError:
+            self = .decodingError(decodingError)
+        default:
+            self = .loadingError(error)
+        }
+    }
+}
+
+public extension APIClientError {
+    var loadingError: Swift.Error? {
+        guard case let .loadingError(value) = self else { return nil }
+        return value
+    }
+
+    var decodingError: DecodingError? {
+        guard case let .decodingError(value) = self else { return nil }
+        return value
+    }
+
+    var apiError: APIError<Error>? {
+        guard case let .apiError(value) = self else { return nil }
+        return value
+    }
 }

--- a/Sources/SimpleNetworking/APIError.swift
+++ b/Sources/SimpleNetworking/APIError.swift
@@ -1,5 +1,5 @@
 //
-// Fixtures.swift
+// APIError.swift
 //
 // Copyright (c) 2020 Guille Gonzalez
 //
@@ -23,28 +23,14 @@
 
 import Foundation
 
-struct User: Equatable, Codable {
-    let name: String
-}
+public struct APIError<Error>: Swift.Error {
+    public let statusCode: Int
+    public let error: Error
 
-struct Error: Equatable, Codable {
-    let message: String
-}
-
-enum Fixtures {
-    static let anyBaseURL = URL(string: "https://example.com")!
-    static let anyUser = User(name: "gonzalezreal")
-    static let anyValidResponse = try! JSONEncoder().encode(anyUser)
-    static let anyError = Error(message: "The resource you requested could not be found.")
-    static let anyErrorResponse = try! JSONEncoder().encode(anyError)
-    static let anyInvalidResponse = "invalid".data(using: .utf8)!
-
-    static func anyURLWithPath(_ path: String, query: String? = nil) -> URL {
-        let url = anyBaseURL.appendingPathComponent(path)
-
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
-        components.query = query
-
-        return components.url!
+    public init(statusCode: Int, error: Error) {
+        self.statusCode = statusCode
+        self.error = error
     }
 }
+
+extension APIError: Equatable where Error: Equatable {}

--- a/Sources/SimpleNetworking/URLRequestAdditions.swift
+++ b/Sources/SimpleNetworking/URLRequestAdditions.swift
@@ -39,7 +39,7 @@ extension URLRequest {
         return result
     }
 
-    public init<Output>(baseURL: URL, endpoint: Endpoint<Output>) {
+    public init<Output, Error>(baseURL: URL, endpoint: Endpoint<Output, Error>) {
         let url = baseURL.appendingPathComponent(endpoint.path)
 
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!

--- a/Tests/SimpleNetworkingTests/EndpointTest.swift
+++ b/Tests/SimpleNetworkingTests/EndpointTest.swift
@@ -27,7 +27,11 @@ import XCTest
 final class EndpointTest: XCTestCase {
     func testEndpointWithoutQuery() {
         // given
-        let endpoint = Endpoint<User>(method: .get, path: "test", headers: [.authorization: "Bearer 3xpo"])
+        let endpoint = Endpoint<User, Error>(
+            method: .get,
+            path: "test",
+            headers: [.authorization: "Bearer 3xpo"]
+        )
         var expected = URLRequest(url: Fixtures.anyURLWithPath("test"))
         expected.addValue("Bearer 3xpo", forHTTPHeaderField: "Authorization")
         expected.addValue(ContentType.json.rawValue, forHTTPHeaderField: "Accept")
@@ -41,7 +45,7 @@ final class EndpointTest: XCTestCase {
 
     func testEndpointWithQuery() {
         // given
-        let endpoint = Endpoint<User>(
+        let endpoint = Endpoint<User, Error>(
             method: .get,
             path: "test",
             headers: [.authorization: "Bearer 3xpo"],
@@ -58,10 +62,10 @@ final class EndpointTest: XCTestCase {
         XCTAssertEqual(result, expected)
     }
 
-    func testEndpointWithBodyAndOutput() {
+    func testEndpointWithBodyAndOutput() throws {
         // given
         let user = User(name: "test")
-        let endpoint = Endpoint<User>(
+        let endpoint = try Endpoint<User, Error>(
             method: .post,
             path: "user/new",
             headers: [.authorization: "Bearer 3xpo"],
@@ -82,10 +86,10 @@ final class EndpointTest: XCTestCase {
         XCTAssertEqual(result, expected)
     }
 
-    func testEndpointWithBody() {
+    func testEndpointWithBody() throws {
         // given
         let user = User(name: "test")
-        let endpoint = Endpoint<Void>(
+        let endpoint = try Endpoint<Void, Error>(
             method: .post,
             path: "user/new",
             headers: [.authorization: "Bearer 3xpo"],
@@ -104,11 +108,4 @@ final class EndpointTest: XCTestCase {
         // then
         XCTAssertEqual(result, expected)
     }
-
-    static var allTests = [
-        ("testEndpointWithoutQuery", testEndpointWithoutQuery),
-        ("testEndpointWithQuery", testEndpointWithQuery),
-        ("testEndpointWithBodyAndOutput", testEndpointWithBodyAndOutput),
-        ("testEndpointWithBody", testEndpointWithBody),
-    ]
 }

--- a/Tests/SimpleNetworkingTests/HTTPURLResponseAdditionsTest.swift
+++ b/Tests/SimpleNetworkingTests/HTTPURLResponseAdditionsTest.swift
@@ -45,13 +45,9 @@ final class HTTPURLResponseAdditionsTest: XCTestCase {
         """
 
         // when
-        let result = anyResponse.logDescription(content: Fixtures.anyJSON.logDescription)
+        let result = anyResponse.logDescription(content: Fixtures.anyValidResponse.logDescription)
 
         // then
         XCTAssertEqual(result, expected)
     }
-
-    static var allTests = [
-        ("testResponseLogDescription", testAnyResponseLogDescription),
-    ]
 }

--- a/Tests/SimpleNetworkingTests/URLRequestAdditionsTest.swift
+++ b/Tests/SimpleNetworkingTests/URLRequestAdditionsTest.swift
@@ -108,12 +108,4 @@ final class URLRequestAdditionsTest: XCTestCase {
         // then
         XCTAssertEqual(result, expected)
     }
-
-    static var allTests = [
-        ("testAnyRequestAddingQueryReturnsExpectedRequest", testAnyRequestAddingQueryReturnsExpectedRequest),
-        ("testAnyRequestAddingHeadersReturnsExpectedRequest", testAnyRequestAddingHeadersReturnsExpectedRequest),
-        ("testAnyRequestLogDescription", testAnyRequestLogDescription),
-        ("testAnyRequestWithHeadersLogDescription", testAnyRequestWithHeadersLogDescription),
-        ("testAnyRequestWithBodyLogDescription", testAnyRequestWithBodyLogDescription),
-    ]
 }


### PR DESCRIPTION
This PR provides better error handling, by unifying all possible errors in an single type `APIClientError`.

On top of that, it provides the means to specify a type for the error response on each endpoint, as suggested in #8.

Additionally, this PR introduces a few changes in the `Endpoint` type to let users of the library completely customise the decoding of responses and error responses, as suggested in #9.

Thanks @kevinrenskers for the feedback.