### PR TITLE
Handle empty error responses

### DIFF
--- a/Sources/SimpleNetworking/APIClient.swift
+++ b/Sources/SimpleNetworking/APIClient.swift
@@ -80,7 +80,7 @@
                     logger.debug("\(httpResponse.logDescription(content: data.logDescription))")
 
                     guard 200 ..< 300 ~= httpResponse.statusCode else {
-                        let error = try apiRequest.error(data)
+                        let error = data.isEmpty ? nil : try apiRequest.error(data)
                         throw APIError(statusCode: httpResponse.statusCode, error: error)
                     }
 

--- a/Sources/SimpleNetworking/APIError.swift
+++ b/Sources/SimpleNetworking/APIError.swift
@@ -29,9 +29,9 @@ public struct APIError<Error>: Swift.Error {
     public let statusCode: Int
 
     /// The error response.
-    public let error: Error
+    public let error: Error?
 
-    public init(statusCode: Int, error: Error) {
+    public init(statusCode: Int, error: Error?) {
         self.statusCode = statusCode
         self.error = error
     }


### PR DESCRIPTION
As mentioned in #21, there are some situations in which the same API request method returns an error payload or no error payload at all when an error occurs.

This code makes the `APIError.error` property optional, to accommodate that case. The `APIClient` will only try to decode an error payload if the response is not empty.